### PR TITLE
Migrate Fabric8 Maven Plugin to Eclipse JKube OpenShift Maven Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
     <vertx.version>3.9.1</vertx.version>
     <vertx-maven-plugin.version>1.0.22</vertx-maven-plugin.version>
     <vertx.verticle>io.openshift.example.HttpApplication</vertx.verticle>
-    <fabric8-maven-plugin.version>4.4.1</fabric8-maven-plugin.version>
+    <jkube.version>1.3.0</jkube.version>
     <arquillian-cube.version>1.18.2</arquillian-cube.version>
 
-    <fabric8.generator.from>registry.access.redhat.com/ubi8/openjdk-11</fabric8.generator.from>
+    <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11</jkube.generator.from>
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -147,12 +147,12 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.fabric8</groupId>
-            <artifactId>fabric8-maven-plugin</artifactId>
-            <version>${fabric8-maven-plugin.version}</version>
+            <groupId>org.eclipse.jkube</groupId>
+            <artifactId>openshift-maven-plugin</artifactId>
+            <version>${jkube.version}</version>
             <executions>
               <execution>
-                <id>fmp</id>
+                <id>jkube</id>
                 <goals>
                   <goal>resource</goal>
                   <goal>build</goal>
@@ -164,12 +164,12 @@
             <configuration>
               <enricher>
                 <excludes>
-                  <exclude>f8-maven-scm</exclude>
+                  <exclude>jkube-maven-scm</exclude>
                 </excludes>
                 <config>
-                  <f8-healthcheck-vertx>
+                  <jkube-healthcheck-vertx>
                     <path>/health</path>
-                  </f8-healthcheck-vertx>
+                  </jkube-healthcheck-vertx>
                 </config>
               </enricher>
               <resources>


### PR DESCRIPTION
Fabric8 Maven Plugin has been refactored to Eclipse JKube. It is advised
to use Eclipse JKube's OpenShift Maven Plugin instead since all future
development will be done in Eclipse JKube and support for FMP would be
eventually dropped.

Related to openshift-vertx-examples/issues#1